### PR TITLE
Use arc4random instead of rand

### DIFF
--- a/Tweak.m
+++ b/Tweak.m
@@ -13,9 +13,8 @@
 @end
 
 void shuffle(int *array, int n) {
-    srand((unsigned)time(NULL));
     for (int i = 0; i < n - 1; i++) {
-        size_t j = i + rand() / (RAND_MAX / (n - i) + 1);
+        int j = i + (int)arc4random_uniform(n - i);
         int t = array[j];
         array[j] = array[i];
         array[i] = t;


### PR DESCRIPTION
`srand()` alters global state. This could be problematic in the context of a tweak that injects into another program. Also, the output of `arc4random_uniform()` doesn't depend on the current time unlike the current implementation.